### PR TITLE
Actualización en nota de datos maestros

### DIFF
--- a/docs/basic-rules/icons-interface.md
+++ b/docs/basic-rules/icons-interface.md
@@ -29,7 +29,7 @@ A su vez, esta forma de visualización permite navegar entre las diferentes pest
 
 ![Ejemplo de una Ventana](/assets/img/docs/basic-rules/bar-icons-windows3.png)
 
-::: note
+::: info
 Para realizar el cambio de visualización utilizamos el botón Multi registro o mono registro (dependiendo de la visual actual de la ventana) del extremo superior izquierdo.
 :::
 

--- a/docs/master-data/index.md
+++ b/docs/master-data/index.md
@@ -18,7 +18,7 @@ _Al ser procesadas las transacciones, el cliente aparece de dististas formas, co
 
 Con este ejemplo visualizamos la gravedad que implica la falta de integración y coherencia de los datos maestros, ahora bien, **Solop ERP** pretende ofrecerle instrucciones precisas en una documentación destinada a definir cada uno de los maestros de Solop ERP, es importante seguir al pie de la letra cada uno de los procedimientos descritos.
 
-::: note
+::: tip
 Sugerimos crear los registros maestros con organización “\*” para asegurar la disponibilidad en multiples organizaciones.
 :::
 

--- a/docs/material-management/inventory-move.md
+++ b/docs/material-management/inventory-move.md
@@ -109,7 +109,7 @@ La opción de Movimiento Rápido permite transferir productos de un almacén a o
 
   * Una vez completados los datos, confirme la operación para registrar el movimiento de stock.
 
-::: note
+::: info
 Asegúrese de verificar los datos antes de confirmar cada operación para evitar errores en el registro de movimientos.
 :::
 

--- a/docs/sales-management/sales-orders/reopen-order.md
+++ b/docs/sales-management/sales-orders/reopen-order.md
@@ -6,3 +6,6 @@ sticky: 9
 article: false
 ---
 
+
+> [!TIP]
+> Optional information to help a user be more successful.


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el texto "Sugerimos crear los registros maestros con organización “*” para asegurar la disponibilidad en multiples organizaciones."

<img width="1366" height="768" alt="datos maestros" src="https://github.com/user-attachments/assets/50689034-fa45-472f-b436-6942347418fe" />
