### PR TITLE
Actualizaciones de notas en facturación electrónica 

### DIFF
--- a/docs/basic-rules/icons-interface.md
+++ b/docs/basic-rules/icons-interface.md
@@ -29,7 +29,7 @@ A su vez, esta forma de visualización permite navegar entre las diferentes pest
 
 ![Ejemplo de una Ventana](/assets/img/docs/basic-rules/bar-icons-windows3.png)
 
-::: note
+::: info
 Para realizar el cambio de visualización utilizamos el botón Multi registro o mono registro (dependiendo de la visual actual de la ventana) del extremo superior izquierdo.
 :::
 

--- a/docs/electronic-billing/electronic-billing-supplier.md
+++ b/docs/electronic-billing/electronic-billing-supplier.md
@@ -40,7 +40,7 @@ Cada documento muestra un campo de *Estado*.
 - Si un CFE fue *rechazado*, se puede editar haciendo clic en el ícono de lápiz para reenviarlo.
 - Recomendación: contactar al soporte antes de realizar modificaciones.
 
-::: note 
+::: tip 
 Cuando el cliente también usa InvoiCy, el sistema envía copias del documento a su email registrado y a la DGI.
 :::
 
@@ -64,7 +64,7 @@ Existen dos métodos para definir el envío por email, que dependen como esté d
 - Ingresar en InvoiCy, consultar el comprobante emitido.
 - En la pestaña **Receptor**, verificar el campo **E-mail receptor**.
 
-::: note 
+::: tip 
 Para deshabilitar el envío automático desde Solop ERP, solicitar al soporte que configure la opción interna "Deshabilitar Envío de mail a BP" en la ventana *Luy Sender*.
 :::
 
@@ -105,7 +105,7 @@ Se tratan de listados con información que completan el control y fiscalización
 - Enviar a DGI  
 - Descargar  
 
-::: warning
+::: tip
 Si el reporte diario fue rechazado, primero validar los CFE emitidos antes de editar o reenviar el reporte. Contactar a soporte si es necesario.
 :::
 

--- a/docs/material-management/inventory-move.md
+++ b/docs/material-management/inventory-move.md
@@ -109,7 +109,7 @@ La opción de Movimiento Rápido permite transferir productos de un almacén a o
 
   * Una vez completados los datos, confirme la operación para registrar el movimiento de stock.
 
-::: note
+::: info
 Asegúrese de verificar los datos antes de confirmar cada operación para evitar errores en el registro de movimientos.
 :::
 

--- a/docs/sales-management/sales-orders/reopen-order.md
+++ b/docs/sales-management/sales-orders/reopen-order.md
@@ -6,3 +6,6 @@ sticky: 9
 article: false
 ---
 
+
+> [!TIP]
+> Optional information to help a user be more successful.


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el texto "Cuando el cliente también usa InvoiCy, el sistema envía copias del documento a su email registrado y a la DGI."

<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/b2bd9f21-cac3-4be5-a671-07225692a216" />


Igualmente se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el texto "Para deshabilitar el envío automático desde Solop ERP, solicitar al soporte que configure la opción interna "Deshabilitar Envío de mail a BP" en la ventana Luy Sender."

<img width="1366" height="768" alt="Screenshot_6" src="https://github.com/user-attachments/assets/bab33d24-e793-4f51-9fd0-c54224c0856e" />

Así mismo se modificó el componente de alertas/notas para que concuerde la etiqueta de visualización de "warning" a "tip" en el texto "Si el reporte diario fue rechazado, primero validar los CFE emitidos antes de editar o reenviar el reporte. Contactar a soporte si es necesario." 

<img width="1366" height="768" alt="Screenshot_21" src="https://github.com/user-attachments/assets/a5c02675-3efa-4607-aacb-0a3462c7172b" />

