### PR TITLE
Actualización de notas en retenciones y resguardos

### DIFF
--- a/docs/basic-rules/icons-interface.md
+++ b/docs/basic-rules/icons-interface.md
@@ -29,7 +29,7 @@ A su vez, esta forma de visualización permite navegar entre las diferentes pest
 
 ![Ejemplo de una Ventana](/assets/img/docs/basic-rules/bar-icons-windows3.png)
 
-::: note
+::: info
 Para realizar el cambio de visualización utilizamos el botón Multi registro o mono registro (dependiendo de la visual actual de la ventana) del extremo superior izquierdo.
 :::
 

--- a/docs/electronic-billing/withholding.md
+++ b/docs/electronic-billing/withholding.md
@@ -81,7 +81,7 @@ Los **resguardos** se generan en base a las retenciones aplicadas. Funcionan com
 - Se pueden preparar o completar inmediatamente.
 - Los resguardos se visualizan en la ventana **Resguardos**.
 
-::: note
+::: tip
 Los resguardos siempre se generan en *moneda local*, convertida con la *tasa de cambio* del documento por pagar.
 :::
 
@@ -109,7 +109,7 @@ Si se anula un resguardo ya completo y enviado a InvoiCy, el sistema:
 - Genera automáticamente un **Contra-Resguardo** (negativo del original).
 - Se enlaza al documento original mediante el campo `Reversal_ID`.
 
-::: note
+::: tip
 El Contra-Resguardo se envía automáticamente a InvoiCy al anular el documento original.
 :::
 

--- a/docs/material-management/inventory-move.md
+++ b/docs/material-management/inventory-move.md
@@ -109,7 +109,7 @@ La opción de Movimiento Rápido permite transferir productos de un almacén a o
 
   * Una vez completados los datos, confirme la operación para registrar el movimiento de stock.
 
-::: note
+::: info
 Asegúrese de verificar los datos antes de confirmar cada operación para evitar errores en el registro de movimientos.
 :::
 

--- a/docs/sales-management/sales-orders/reopen-order.md
+++ b/docs/sales-management/sales-orders/reopen-order.md
@@ -6,3 +6,6 @@ sticky: 9
 article: false
 ---
 
+
+> [!TIP]
+> Optional information to help a user be more successful.


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el texto "Los resguardos siempre se generan en moneda local, convertida con la tasa de cambio del documento por pagar. "

<img width="1366" height="768" alt="Screenshot_10" src="https://github.com/user-attachments/assets/af0e45b8-86c3-4a51-8ffe-da0a2de8806e" />

Igualmente se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el texto "El Contra-Resguardo se envía automáticamente a InvoiCy al anular el documento original. "

<img width="1366" height="768" alt="Screenshot_11" src="https://github.com/user-attachments/assets/2de139ee-6a14-4299-b93c-cfb45a0fd6a1" />
