### PR TITLE
Actualización de nota en tipo de aplicación 

### DIFF
--- a/docs/accounting-management/type-application.md
+++ b/docs/accounting-management/type-application.md
@@ -62,7 +62,7 @@ El resultado con este tipo de aplicación, sería el siguiente:
 
 Imagen 1. Información Contable Actual
 
-::: note
+::: tip
 El tipo de aplicación actual, es predeterminado en toda transacción realizada y reportes generados desde Solop ERP.
 :::
 

--- a/docs/basic-rules/icons-interface.md
+++ b/docs/basic-rules/icons-interface.md
@@ -29,7 +29,7 @@ A su vez, esta forma de visualización permite navegar entre las diferentes pest
 
 ![Ejemplo de una Ventana](/assets/img/docs/basic-rules/bar-icons-windows3.png)
 
-::: note
+::: info
 Para realizar el cambio de visualización utilizamos el botón Multi registro o mono registro (dependiendo de la visual actual de la ventana) del extremo superior izquierdo.
 :::
 

--- a/docs/material-management/inventory-move.md
+++ b/docs/material-management/inventory-move.md
@@ -109,7 +109,7 @@ La opción de Movimiento Rápido permite transferir productos de un almacén a o
 
   * Una vez completados los datos, confirme la operación para registrar el movimiento de stock.
 
-::: note
+::: info
 Asegúrese de verificar los datos antes de confirmar cada operación para evitar errores en el registro de movimientos.
 :::
 

--- a/docs/sales-management/sales-orders/reopen-order.md
+++ b/docs/sales-management/sales-orders/reopen-order.md
@@ -6,3 +6,6 @@ sticky: 9
 article: false
 ---
 
+
+> [!TIP]
+> Optional information to help a user be more successful.


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el texto "El tipo de aplicación actual, es predeterminado en toda transacción realizada y reportes generados desde Solop ERP."

<img width="1366" height="768" alt="Screenshot_12" src="https://github.com/user-attachments/assets/77e85cc0-6cf5-40d7-91e5-0b4c8acc2ce7" />

