### PR TITLE
Actualización de notas en cierre de balance

### DIFF
--- a/docs/accounting-management/accounting-documents/accounting.md
+++ b/docs/accounting-management/accounting-documents/accounting.md
@@ -141,7 +141,7 @@ Ubique el documento de factura por pagar asociado al pago y seleccione la pesta�
 
 Imagen 13. Asignación Factura Pago
 
-::: note
+::: tip
 La asignación **Factura/Pago**, es generada automáticamente después de completar el documento **Pago**, asociado a la factura.
 :::
 
@@ -363,7 +363,7 @@ Imagen 2. Asiento Contable de la Nómina
 
 Realice el procedimiento regular para reflejar en Solop ERP el pago de la nómina por empleado, el mismo se encuentra explicado en el documento Registro de Pagos de Nómina, elaborado por Solop ERP.
 
-::: note
+::: tip
 El pago de nómina que se genera al cumplir con todos los procesos que indica el documento, rebaja el pasivo.
 :::
 

--- a/docs/accounting-management/accounting-procedures/balance-sheet-closing.md
+++ b/docs/accounting-management/accounting-procedures/balance-sheet-closing.md
@@ -39,7 +39,7 @@ El Lote del  Asiento Contable deberá completarse
 
 Si desea anular un Asiento ya Completo deberá Anular y Corregir para que la fecha de anulación sea la misma que la del asiento.
 
-::: warning
+::: tip
 CUIDADO La acción Anular y Causación crea el asiento con la fecha de hoy.
 :::
 
@@ -90,7 +90,7 @@ El proceso de cambio de cuentas integrales analiza aquellas cuentas contables qu
 
 Si dicha cuenta tiene un saldo en alguna moneda extranjera, aplicará un asiento de ajuste por el importe en UYU que falte para que los USD queden registrados con su correcta conversión.
 
-::: note
+::: tip
 Importante: El proceso de "Diferencia de Cambio Cuentas Integrales" no mira saldos totales de cuentas contables a la fecha, sino que mira exclusivamente el saldo en cada una de las correspondientes monedas fuente. Esto significa que si bien una cuenta pueda tener un saldo cero a final de ejercicio, luego que se corra el proceso de diferencia de cambio, se actualizarán los USD que no estén actualizados correctamente y le aplicará un asiento de ajuste por diferencia de cambio de cuenta integral (Monetaria).
 :::
 

--- a/docs/basic-rules/icons-interface.md
+++ b/docs/basic-rules/icons-interface.md
@@ -29,7 +29,7 @@ A su vez, esta forma de visualización permite navegar entre las diferentes pest
 
 ![Ejemplo de una Ventana](/assets/img/docs/basic-rules/bar-icons-windows3.png)
 
-::: note
+::: info
 Para realizar el cambio de visualización utilizamos el botón Multi registro o mono registro (dependiendo de la visual actual de la ventana) del extremo superior izquierdo.
 :::
 

--- a/docs/material-management/inventory-move.md
+++ b/docs/material-management/inventory-move.md
@@ -109,7 +109,7 @@ La opción de Movimiento Rápido permite transferir productos de un almacén a o
 
   * Una vez completados los datos, confirme la operación para registrar el movimiento de stock.
 
-::: note
+::: info
 Asegúrese de verificar los datos antes de confirmar cada operación para evitar errores en el registro de movimientos.
 :::
 

--- a/docs/sales-management/sales-orders/reopen-order.md
+++ b/docs/sales-management/sales-orders/reopen-order.md
@@ -6,3 +6,6 @@ sticky: 9
 article: false
 ---
 
+
+> [!TIP]
+> Optional information to help a user be more successful.


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" y asi concuerde con el resto de alertas/notas, se realizo el cambio en el siguiente texto "CUIDADO La acción Anular y Causación crea el asiento con la fecha de hoy."

<img width="1366" height="768" alt="Screenshot_10" src="https://github.com/user-attachments/assets/c0948606-b9dc-438e-b888-711ef849f804" />

Adicional se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Importante: El proceso de "Diferencia de Cambio Cuentas Integrales" no mira saldos totales de cuentas contables a la fecha, sino que mira exclusivamente el saldo en cada una de las correspondientes monedas fuente. Esto significa que si bien una cuenta pueda tener un saldo cero a final de ejercicio, luego que se corra el proceso de diferencia de cambio, se actualizarán los USD que no estén actualizados correctamente y le aplicará un asiento de ajuste por diferencia de cambio de cuenta integral (Monetaria)."
<img width="1366" height="768" alt="Screenshot_11" src="https://github.com/user-attachments/assets/c1e651b1-5730-44a9-8d61-adea77c15dc0" />
