### PR TITLE
Actualización de notas en documentos sin aplicar

### DIFF
--- a/docs/accounting-management/accounting-rules/document.md
+++ b/docs/accounting-management/accounting-rules/document.md
@@ -27,7 +27,7 @@ Seleccione la opción **No Contabilizado**, para contabilizar el registro del do
 
 Imagen 3. Opción Contabilizado de la Ventana Documentos sin Aplicar
 
-::: note
+::: tip
 Para contabilizar un registro, es necesario que el mismo tenga asociado un número de documento en el campo **No. del Documento** y el estado del documento debe ser **Completo** o **Cerrado**.
 :::
 
@@ -37,6 +37,6 @@ Podrá visualizar la ventana de confirmación **Documentos sin Aplicar**, donde 
 
 Imagen 4. Ventana de Confirmación para Crear Entradas Contables
 
-::: note
+::: tip
 Luego de contabilizado el registro, la ventana se actualiza y es restado el mismo al número de líneas o registros que contiene dicha ventana.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Para contabilizar un registro, es necesario que el mismo tenga asociado un número de documento en el campo No. del Documento y el estado del documento debe ser Completo o Cerrado." y en el texto "Luego de contabilizado el registro, la ventana se actualiza y es restado el mismo al número de líneas o registros que contiene dicha ventana."

<img width="1366" height="768" alt="Screenshot_18" src="https://github.com/user-attachments/assets/8b3adb40-3e87-4f77-80d8-2b1b7b10cd3d" />

