### PR TITLE
Actualización de notas en conversión monetaria

### DIFF
--- a/docs/accounting-management/accounting-rules/conversion.md
+++ b/docs/accounting-management/accounting-rules/conversion.md
@@ -35,7 +35,7 @@ Imagen 1. Ejemplo de Validación
 
 Crear Tasa Recíproca: Esta funcionalidad permite que al guardar el registro sea creada de manera automática una tasa de cambio como reverso.
 
-::: note
+::: tip
 Un ejemplo de este caso puede ser cuando el usuario crea una tasa de cambio de moneda **UYU** a moneda **USD** con una tasa multiplicadora 2 entonces automáticamente se creará una tasa de cambio de moneda **USD** a **UYU** con la tasa multiplicadora 0.5
 :::
 
@@ -73,7 +73,7 @@ El checklist **Activo**, indica que el registro se encuentra activo y puede ser 
 
 Seleccione el checklist **Predeterminado**, para indicar como predeterminado el registro que se encuentra realizando.
 
-::: note
+::: tip
 Recuerde guardar los cambios realizados seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -99,7 +99,7 @@ Imagen 13. Pestaña Tasas de Cambio de la Ventana Moneda
 
 Seleccione el icono **Registro Nuevo** para crear un nuevo registro de tasas de cambio.
 
-::: warning
+::: tip
 La tasa de cambio se debe crear de dólares a pesos y de pesos a dólares.
 :::
 
@@ -113,7 +113,7 @@ Seleccione en el campo **Válido Hasta**, la fecha hasta la cual es válida la t
 
 Introduzca en el campo **Factor de Base a Destino**, la tasa por la que serán multiplicados los montos de las transacciones donde sea utilizado el tipo de conversión seleccionado anteriormente. Para ejemplificar el registro es utilizada la tasa **40,0**.
 
-::: note
+::: tip
 Recuerde guardar los cambios realizados seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -147,7 +147,7 @@ Seleccione en el campo **Válido Hasta**, la fecha final del periodo de validez 
 
 Introduzca en el campo **Factor de Destino a Base**, la tasa por la que serán multiplicados los montos de las transacciones donde sea utilizado el tipo de conversión seleccionado anteriormente. Para ejemplificar el registro es utilizada la tasa **40,0**.
 
-::: note
+::: tip
 Recuerde guardar los cambios realizados seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Un ejemplo de este caso puede ser cuando el usuario crea una tasa de cambio de moneda UYU a moneda USD con una tasa multiplicadora 2 entonces automáticamente se creará una tasa de cambio de moneda USD a UYU con la tasa multiplicadora 0.5"

<img width="1366" height="768" alt="Screenshot_20" src="https://github.com/user-attachments/assets/0984b37c-075e-4a78-ba10-ed5f4b6c83e4" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar los cambios realizados seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_21" src="https://github.com/user-attachments/assets/4d7aa8c8-3737-448c-8483-5b00a9745c75" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" para que concuerden en el siguiente texto "La tasa de cambio se debe crear de dólares a pesos y de pesos a dólares." y a su vez en el texto "Recuerde guardar los cambios realizados seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_22" src="https://github.com/user-attachments/assets/17f4183d-7a92-42ce-8998-95a931d73fac" />

Y por ultimo se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar los cambios realizados seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_23" src="https://github.com/user-attachments/assets/e04a0531-c606-400a-8dcd-8973d0c3e116" />


