### PR TITLE
Actualización de notas en distribución contable

### DIFF
--- a/docs/accounting-management/accounting-rules/distribution.md
+++ b/docs/accounting-management/accounting-rules/distribution.md
@@ -104,7 +104,7 @@ El checklist **Crear Reversión**, indica que el movimiento de reversión se cre
 
 Imagen 9. Checklist Crear Reversión de la Ventana Distribución Contable
 
-::: warning
+::: tip
 Si se inhabilita el checklist, el movimiento original será borrado.
 :::
 
@@ -204,7 +204,7 @@ Al destildar el checklist **Cualquier Usuario 1**, se habilita el campo **Centro
 
 Imagen 25. Campo Centro de Costos del Checklist Cualquier Usuario 1 de la Ventana Distribución Contable
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña antes de posicionarse en otra pestaña de la misma ventana, seleccionando el icono **Guardar Cambios** ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -246,7 +246,7 @@ El checklist **Signo de cuenta invertida**,
 
 Imagen 31. Checklist Signo de Cuenta Invertida de la Pestaña Línea de la Ventana Distribución Contable
 
-::: note
+::: tip
 Al seleccionar el checklist **Signo de cuenta invertida**, no se habilita ningún campo.
 :::
 
@@ -340,7 +340,7 @@ El checklist **Sobreescribe Usuario 3**,
 
 Imagen 46. Checklist Sobreescribe Usuario 3 de la Pestaña Línea de la Ventana Distribución Contable
 
-::: note
+::: tip
 Al seleccionar el checklist **Sobreescribe Usuario 3**, no se habilita ningún campo.
 :::
 
@@ -350,7 +350,7 @@ El checklist **Sobreescribe Usuario 4**,
 
 Imagen 47. Checklist Sobreescribe Usuario 4 de la Pestaña Línea de la Ventana Distribución Contable
 
-::: note
+::: tip
 Al seleccionar el checklist **Sobreescribe Usuario 4**, no se habilita ningún campo.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" en el siguiente texto "Si se inhabilita el checklist, el movimiento original será borrado."
<img width="1366" height="768" alt="Screenshot_24" src="https://github.com/user-attachments/assets/59e519ee-a526-4330-abeb-ebff9d4507e7" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña antes de posicionarse en otra pestaña de la misma ventana, seleccionando el icono Guardar Cambios ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_25" src="https://github.com/user-attachments/assets/e9e545fe-aaa9-4435-bf74-8fb4f22cf39a" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al seleccionar el checklist Signo de cuenta invertida, no se habilita ningún campo."
<img width="1366" height="768" alt="Screenshot_26" src="https://github.com/user-attachments/assets/d9a2e74b-84f3-439c-a1bd-10a2ed7875b2" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al seleccionar el checklist Sobreescribe Usuario 3, no se habilita ningún campo." y en el texto "Al seleccionar el checklist Sobreescribe Usuario 4, no se habilita ningún campo."

<img width="1366" height="768" alt="Screenshot_27" src="https://github.com/user-attachments/assets/9c50167e-e4b7-4e68-af7a-199b64dc71a2" />
