### PR TITLE
Actualización de notas en configuración contable

### DIFF
--- a/docs/accounting-management/accounting-rules/configuration.md
+++ b/docs/accounting-management/accounting-rules/configuration.md
@@ -68,7 +68,7 @@ Seleccione la pestaña **Contabilidad** para definir la configuración contable 
 
 Imagen 3. Pestaña Contabilidad
 
-::: note
+::: tip
 Por defecto, la pestaña **Contabilidad**, trae precargados los campos **Compañía**, **Organización** y **Producto** con la información ingresada en la pestaña **Producto**. De igual forma, al seleccionar la versión de lista de precios en la pestaña **Precio**, trae cargado el esquema contable configurado.
 :::
 
@@ -164,7 +164,7 @@ Seleccione el identificador ubicado del lado derecho del campo **CxC Pago Antici
 
 Realice el procedimiento regular para configurar una combinación contable, el mismo se encuentra explicado en el documento Combinación Contable elaborado por Solop ERP.
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña **Contabilidad Cliente**, seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -206,7 +206,7 @@ Seleccione el identificador ubicado del lado derecho del campo **Anticipo del Pr
 
 Realice el procedimiento regular para configurar una combinación contable, el mismo se encuentra explicado en el documento Combinación Contable elaborado por Solop ERP.
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña **Contabilidad Proveedor**, seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -244,7 +244,7 @@ Seleccione el identificador ubicado del lado derecho del campo **Pago Anticipado
 
 Realice el procedimiento regular para configurar una combinación contable, el mismo se encuentra explicado en el documento Combinación Contable elaborado por Solop ERP.
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña **Contabilidad Empleado**, seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -262,7 +262,7 @@ Podrá visualizar la ventana **Catálogo de Concepto**, con los diferentes regis
 
 Imagen 2. Ventana Catálogo de Concepto
 
-::: note
+::: tip
 Todo concepto de asignación debe tener en el campo **Naturaleza de Cuenta**, la opción **Débito**. De igual manera, todo concepto de deducción debe tener en el campo **Naturaleza de Cuenta**, la opción **Crédito**.
 :::
 
@@ -366,7 +366,7 @@ Seleccione el identificador ubicado del lado derecho del campo **Pérdida por Aj
 
 Realice el procedimiento regular para configurar una combinación contable, el mismo se encuentra explicado en el documento Combinación Contable elaborado por Solop ERP.
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña **Contabilidad**, seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -444,7 +444,7 @@ Seleccione el identificador ubicado del lado derecho del campo **Pérdida por Aj
 
 Realice el procedimiento regular para configurar una combinación contable, el mismo se encuentra explicado en el documento Combinación Contable elaborado por Solop ERP.
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña **Contabilidad**, seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::
 
@@ -488,6 +488,6 @@ Seleccione el identificador ubicado del lado derecho del campo **Gastos Impuesto
 
 Realice el procedimiento regular para configurar una combinación contable, el mismo se encuentra explicado en el documento Combinación Contable elaborado por Solop ERP.
 
-::: note
+::: tip
 Recuerde guardar el registro de los campos de la pestaña **Contabilidad**, seleccionando el icono **Guardar Cambios**, ubicado en la barra de herramientas de Solop ERP.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Por defecto, la pestaña Contabilidad, trae precargados los campos Compañía, Organización y Producto con la información ingresada en la pestaña Producto. De igual forma, al seleccionar la versión de lista de precios en la pestaña Precio, trae cargado el esquema contable configurado."
<img width="1366" height="768" alt="Screenshot_28" src="https://github.com/user-attachments/assets/8d89126f-e728-4761-9622-e8002a5a670d" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña Contabilidad Cliente, seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_29" src="https://github.com/user-attachments/assets/bf442342-e2a3-4094-9adb-173030bafae4" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña Contabilidad Proveedor, seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_30" src="https://github.com/user-attachments/assets/3458e706-f3fa-41ce-9192-3c2e00d88479" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña Contabilidad Empleado, seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_31" src="https://github.com/user-attachments/assets/003f666f-9fb3-4d84-ba96-bb103b62bbc5" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Todo concepto de asignación debe tener en el campo Naturaleza de Cuenta, la opción Débito. De igual manera, todo concepto de deducción debe tener en el campo Naturaleza de Cuenta, la opción Crédito."
<img width="1366" height="522" alt="Screenshot_32" src="https://github.com/user-attachments/assets/afe6c815-5eee-4d12-9a40-9def99566042" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña Contabilidad, seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_33" src="https://github.com/user-attachments/assets/f50cce2b-b280-47bf-894e-b055f488bab3" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña Contabilidad, seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_34" src="https://github.com/user-attachments/assets/bb71627b-3b07-4fe6-9b18-f0160ae3dd71" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde guardar el registro de los campos de la pestaña Contabilidad, seleccionando el icono Guardar Cambios, ubicado en la barra de herramientas de Solop ERP."
<img width="1366" height="768" alt="Screenshot_35" src="https://github.com/user-attachments/assets/47657555-b6b8-4a39-9d39-b6fdd2d706b5" />
