### PR TITLE
Actualización de notas en informes financieros

### DIFF
--- a/docs/accounting-management/accounting-reports/reports.md
+++ b/docs/accounting-management/accounting-reports/reports.md
@@ -106,6 +106,6 @@ Luego de que haya culminado el procedimiento, podrá visualizar la ventana **Inf
 
 Imagen 5. Estado de Resultado
 
-::: note
+::: tip
 El reporte de estado de resultado muestra la información en base al periodo de tiempo seleccionado en el campo **Periodo** de la ventana **Crear Informe**.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "El reporte de estado de resultado muestra la información en base al periodo de tiempo seleccionado en el campo Periodo de la ventana Crear Informe."
<img width="1366" height="768" alt="Screenshot_38" src="https://github.com/user-attachments/assets/fc799cbd-5487-4869-9812-1798052d8298" />
