### PR TITLE
Actualización de notas en solicitud de cotización a proveedor

### DIFF
--- a/docs/purchase-management/application.md
+++ b/docs/purchase-management/application.md
@@ -113,7 +113,7 @@ Ubique y seleccione en el menú de Solop ERP, la carpeta **Gestión de Compras**
 
 Imagen 13. Menú de Solop ERP
 
-::: note
+::: tip
 Solop ERP permite que la solicitud para cotización sea realizada de tres (3) formas, definidas por el campo **Tipo SCP (RfQ)**.
 :::
 
@@ -217,7 +217,7 @@ Podrá visualizar la ventana **Solicitud para Cotización con Respuesta**, con l
 
 Imagen 34. Ventana de Solicitud para Cotización con Respuesta
 
-::: note
+::: tip
 Solop ERP crea tantos registros de solicitud de cotización con respuesta como proveedores tenga la solicitud de cotización realizada por la empresa. Cada registro creado de una solicitud de cotización contiene su mismo número de documento en el campo **SCP (RfQ)**.
 :::
 
@@ -239,7 +239,7 @@ Seleccione la pestaña **Línea Respuesta** para navegar entre los registros de 
 
 Imagen 36. Pestaña Línea Respuesta
 
-::: note
+::: tip
 Puede visualizar en la parte inferior derecha de la pestaña, la cantidad de registros de productos cotizados que posee el socio del negocio proveedor.
 :::
 
@@ -279,7 +279,7 @@ Podrá visualizar que el checklist **Completo** se tilda automáticamente al com
 
 Imagen 43. Checklist Completo
 
-::: note
+::: tip
 Repita en cada uno de los registros de socios del negocio proveedores de la **Solicitud para Cotización (Con Respuesta) por Tipo Cotiza Líneas Seleccionadas**, el procedimiento explicado anteriormente.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Solop ERP permite que la solicitud para cotización sea realizada de tres (3) formas, definidas por el campo Tipo SCP (RfQ)."
<img width="1366" height="768" alt="Screenshot_39" src="https://github.com/user-attachments/assets/a6f7132e-5981-48dc-87b7-5713778af38f" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Solop ERP crea tantos registros de solicitud de cotización con respuesta como proveedores tenga la solicitud de cotización realizada por la empresa. Cada registro creado de una solicitud de cotización contiene su mismo número de documento en el campo SCP (RfQ)."
<img width="1366" height="768" alt="Screenshot_40" src="https://github.com/user-attachments/assets/ee4fd983-26f8-4eb6-8de7-09d77a43ea22" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Puede visualizar en la parte inferior derecha de la pestaña, la cantidad de registros de productos cotizados que posee el socio del negocio proveedor."
<img width="1366" height="516" alt="Screenshot_41" src="https://github.com/user-attachments/assets/48b4b91f-d5b1-43f9-ac73-77b390ef5916" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Repita en cada uno de los registros de socios del negocio proveedores de la Solicitud para Cotización (Con Respuesta) por Tipo Cotiza Líneas Seleccionadas, el procedimiento explicado anteriormente."
<img width="1366" height="768" alt="Screenshot_42" src="https://github.com/user-attachments/assets/3a574c16-3f12-4709-998b-b20e22d9b49e" />
