### PR TITLE
Actualización de notas en Tasa de Conversión Negociada

### DIFF
--- a/docs/purchase-management/conversion.md
+++ b/docs/purchase-management/conversion.md
@@ -76,7 +76,7 @@ Finalmente, la tasa cambio de la negociación se debe ingresar en el campo **Tas
 
 Imagen 10. Campo Tasa de Cambio Negociada de la Pestaña Conversión de Moneda de la Orden de Compra
 
-::: note
+::: tip
 Recuerde que debe guardar el registro de los campos, antes de posicionarse en cualquier otra pestaña de la ventana **Órdenes de Compra**.
 :::
 
@@ -94,6 +94,6 @@ Adicionalmente, se reemplaza el tipo de conversión de la pestaña **Conversión
 
 Imagen 12. Tipo de Conversión de la Negociación en Pestaña Conversión de Moneda de la Orden de Compra
 
-::: note
+::: tip
 Al momento de realizar el documento por pagar correspondiente a la orden de compra previamente creada, Solop ERP respeta el tipo de conversión y la tasa de cambio negociada que contiene dicha orden, generando el documento con los mismos valores en cuanto al tipo de conversión y la tasa de cambio.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde que debe guardar el registro de los campos, antes de posicionarse en cualquier otra pestaña de la ventana Órdenes de Compra."
<img width="1366" height="768" alt="Screenshot_48" src="https://github.com/user-attachments/assets/dc95870c-ba9d-4eb7-b43f-12496be020c5" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al momento de realizar el documento por pagar correspondiente a la orden de compra previamente creada, Solop ERP respeta el tipo de conversión y la tasa de cambio negociada que contiene dicha orden, generando el documento con los mismos valores en cuanto al tipo de conversión y la tasa de cambio."
<img width="1366" height="768" alt="Screenshot_49" src="https://github.com/user-attachments/assets/48747f30-d3ed-4372-9af0-aec0a860cb67" />

