### PR TITLE
Actualización de nota en Gestión de Documento por Pagar

### DIFF
--- a/docs/purchase-management/payable-documents/document.md
+++ b/docs/purchase-management/payable-documents/document.md
@@ -177,7 +177,7 @@ Imagen 60. Campo Total de Líneas
 
 De igual manera, podrá visualizar en el campo **Gran Total**, la sumatoria de todos los montos reflejados en el campo **Total de la Línea**, de todas las líneas que contiene el documento por pagar.
 
-::: note
+::: tip
 El gran total identifica el total incluyendo impuestos y totales de fletes en la moneda del documento.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "El gran total identifica el total incluyendo impuestos y totales de fletes en la moneda del documento."
<img width="1366" height="722" alt="Screenshot_26" src="https://github.com/user-attachments/assets/25bbc492-e968-4206-802c-3312e102fff2" />
