### PR TITLE
Actualización de notas en Devolución a Cliente

### DIFF
--- a/docs/return-management/customer-return.md
+++ b/docs/return-management/customer-return.md
@@ -54,7 +54,7 @@ Este módulo permite gestionar el proceso completo de **devoluciones de producto
 - Seleccionar las líneas y cantidades a devolver (puede ser **parcial o total**).
 - Confirmar y guardar. Se genera una **Orden de Devolución**, con valor y precio correspondiente.
 
-> :::note
+> :::tip
 > Esta orden de devolución **no genera aún movimiento de inventario**. Su comportamiento es opuesto a una orden de venta.
 > :::
 
@@ -87,7 +87,7 @@ Este módulo permite gestionar el proceso completo de **devoluciones de producto
 - Seleccionar la línea (por ejemplo, de la orden 810).
 - Cargar y completar la Nota de Crédito.
 
-> :::note
+> :::tip
 > La nota de crédito se genera por el importe original facturado de los productos devueltos.
 > :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Esta orden de devolución no genera aún movimiento de inventario. Su comportamiento es opuesto a una orden de venta."
<img width="1366" height="722" alt="Screenshot_27" src="https://github.com/user-attachments/assets/7305907a-313b-4827-ab83-5a8ea1c9919b" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "La nota de crédito se genera por el importe original facturado de los productos devueltos."
<img width="1366" height="727" alt="Screenshot_28" src="https://github.com/user-attachments/assets/344440ec-d089-47d1-9dc0-3b08f6927a3e" />
