### PR TITLE
Actualización de notas en Devolución a Proveedor

### DIFF
--- a/docs/return-management/provider-return.md
+++ b/docs/return-management/provider-return.md
@@ -52,7 +52,7 @@ Este módulo permite gestionar el proceso completo de **devoluciones de producto
 - Seleccionar las líneas y cantidades a devolver (puede ser **parcial o total**).
 - Confirmar y guardar. Se genera una **Orden de Devolución**, con valor y precio correspondiente.
 
-> :::note
+> :::tip
 > Esta orden de devolución **no genera aún movimiento de inventario**. Su comportamiento es opuesto a una orden de venta.
 > :::
 
@@ -77,7 +77,7 @@ Este módulo permite gestionar el proceso completo de **devoluciones de producto
 - Seleccionar la línea (por ejemplo, de la orden 810).
 - Cargar y completar la Nota de Crédito.
 
-> :::note
+> :::tip
 > La nota de crédito se genera por el importe original facturado de los productos devueltos.
 > :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Esta orden de devolución no genera aún movimiento de inventario. Su comportamiento es opuesto a una orden de venta."
<img width="1366" height="722" alt="Screenshot_30" src="https://github.com/user-attachments/assets/5750a89b-8602-4ec5-9f10-a24fa62bea5c" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "La nota de crédito se genera por el importe original facturado de los productos devueltos."
<img width="1366" height="768" alt="Screenshot_31" src="https://github.com/user-attachments/assets/b211f41d-010a-4726-bb35-7a4a1ea8be39" />
