### PR TITLE
Actualización de notas en Orden de Distribución

### DIFF
--- a/docs/distribution-management/distribution-order.md
+++ b/docs/distribution-management/distribution-order.md
@@ -95,7 +95,7 @@ Asegurar que los movimientos de inventario entre locales/almacenes:
 
       * Ubicación destino.
 
-::: note
+::: tip
 - Si cantidad confirmada > existencia, el sistema solo mueve lo disponible (ej. existencia 20 → moverá 20).
 - Solo se moverá lo cantidad mayor a existencia si la orden está marcada como regla de entrega forzada.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si cantidad confirmada > existencia, el sistema solo mueve lo disponible (ej. existencia 20 → moverá 20).
Solo se moverá lo cantidad mayor a existencia si la orden está marcada como regla de entrega forzada."

<img width="1366" height="768" alt="Screenshot_40" src="https://github.com/user-attachments/assets/8f87e41f-fe42-4dbc-a657-e3bb70670940" />

