### PR TITLE
Actualización de nota en Acciones del Punto de Venta

### DIFF
--- a/docs/pdv-management/opening.md
+++ b/docs/pdv-management/opening.md
@@ -29,7 +29,7 @@ Adicionalmente, se crea un registro en Cierre de Caja, con la cuenta Caja POS, a
 6. Aceptar.
 
 
-::: note
+::: tip
 * Este proceso debe realizarse antes de iniciar las ventas del día.
 
 * No se debe realizar la apertura de caja sin haber entregado físicamente el dinero correspondiente. De lo contrario, los saldos en Solop ERP no coincidirán con los saldos físicos.
@@ -70,7 +70,7 @@ El proceso de Copiar Orden Desde Otra permite duplicar una orden de venta manten
 * Seleccionar la opción Copiar Orden.
 
 
-::: note
+::: tip
 * Si el terminal requiere un PIN de usuario, se debe ingresar antes de ejecutar el proceso.
 
 * Una vez copiada, la orden se generará en estado Borrador con la fecha actual.
@@ -245,7 +245,7 @@ Un retiro de fondos ocurre cuando se extrae dinero de una caja del punto de vent
 * Seleccionar [Transferir Fondos].
 * Aceptar
 
-::: note
+::: tip
 Por cada retiro realizado, Solop ERP genera en la ventana Caja:
 * Un documento de pago asociando la caja POS.
 * Un documento de cobro asociando la caja administrativa.
@@ -335,7 +335,7 @@ Para habilitar el cambio en otra moneda:
 
 * Activar el campo “Is Allowed To Refund”.
 
-::: note
+::: tip
 Este check es indispensable para que el método de pago esté disponible en la pantalla de cambio.
 :::
 
@@ -361,7 +361,7 @@ Para que sea posible cobrar en una moneda distinta a la de la factura, el métod
 
 #### Ejemplo funcional: El método de pago Mastercard permite seleccionar una moneda diferente porque no tiene moneda fija asignada.
 
-::: note
+::: tip
 Excepción: El método de pago Efectivo tiene una moneda fija configurada, por lo tanto no permite seleccionar otra moneda al momento del cobro.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Este proceso debe realizarse antes de iniciar las ventas del día.
No se debe realizar la apertura de caja sin haber entregado físicamente el dinero correspondiente. De lo contrario, los saldos en Solop ERP no coincidirán con los saldos físicos.
Es obligatorio seleccionar la opción OK en la ventana Transferencia Bancaria para completar el proceso y reflejar el movimiento monetario en Solop ERP.
Si se requiere aperturar la caja con más de una moneda, se debe realizar una transferencia por cada moneda."

<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/d484d7d2-5ac6-4e22-b483-b1c4fb866e11" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si el terminal requiere un PIN de usuario, se debe ingresar antes de ejecutar el proceso.
Una vez copiada, la orden se generará en estado Borrador con la fecha actual.
Si se va a generar una nota de crédito, la orden debe copiarse antes de realizar la devolución, ya que al generarse la nota de crédito la orden original pasará a estado Cerrado."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/567bad00-bd02-439d-8c25-35253e9a3e3e" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Por cada retiro realizado, Solop ERP genera en la ventana Caja:Un documento de pago asociando la caja POS.
Un documento de cobro asociando la caja administrativa."
<img width="1366" height="768" alt="Screenshot_7" src="https://github.com/user-attachments/assets/e390b397-7b8d-4336-9b8e-d99296e174e1" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Este check es indispensable para que el método de pago esté disponible en la pantalla de cambio."
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/5b7f8555-4655-4172-80c7-51429b58e64d" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Excepción: El método de pago Efectivo tiene una moneda fija configurada, por lo tanto no permite seleccionar otra moneda al momento del cobro."
<img width="1366" height="768" alt="Screenshot_6" src="https://github.com/user-attachments/assets/dc3a2b95-6cd6-47cb-920c-d1b4ea8f4d0b" />