### PR TITLE
Actualización de nota en Reabastecimiento de Almacén

### DIFF
--- a/docs/material-management/replenishment-process/replenishment.md
+++ b/docs/material-management/replenishment-process/replenishment.md
@@ -110,7 +110,7 @@ Al seleccionar el registro del produto, se habilita el campo de la columna **Can
 
 Seleccione en el campo **Crear**, el documento que requiere crear para reabastecer el producto en el almacén seleccionado.
 
-::: note
+::: tip
 Cuando se requiere generar el documento **Orden de Compra**, es obligatorio seleccionar el socio del negocio proveedor en la columna **Socio del Negocio** de la ventana **Reabastecimiento de Almacén**.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Cuando se requiere generar el documento Orden de Compra, es obligatorio seleccionar el socio del negocio proveedor en la columna Socio del Negocio de la ventana Reabastecimiento de Almacén."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/3f810004-0a46-4c0d-93d5-575cfb4616cb" />
