### PR TITLE
Actualización de nota en Uso del Punto de Venta

### DIFF
--- a/docs/pdv-management/point-interface.md
+++ b/docs/pdv-management/point-interface.md
@@ -43,7 +43,7 @@ Permite buscar productos por:
 * Precio Estándar
 * Precio de Lista
 
-::: note
+::: tip
 La búsqueda se ejecuta automáticamente al ingresar el código del producto.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "La búsqueda se ejecuta automáticamente al ingresar el código del producto."

<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/deb405b2-6eaa-4dc1-90e9-8c445364e874" />
