### PR TITLE
Actualización de notas en Gestión de Morosidad

### DIFF
--- a/docs/balance-management/default-management-general/default-management.md
+++ b/docs/balance-management/default-management-general/default-management.md
@@ -63,7 +63,7 @@ En las líneas de cada entrada se visualiza:
 
 ![Entradas](/assets/img/docs/balance-management/bam-default19.png)
 
-::: note
+::: tip
 Si el check “No Muestra Deuda” está marcado, también se mostrarán facturas no vencidas.
 Si el check no está marcado, facturas con días de vencido < 0 no se mostrarán.
 :::
@@ -152,6 +152,6 @@ El proceso garantiza:
 
 * Envío automático de notificaciones con trazabilidad.
 
-::: note
+::: tip
 Se recomienda siempre revisar la Cola de Notificaciones para confirmar que no existan rebotes o errores de envío.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si el check “No Muestra Deuda” está marcado, también se mostrarán facturas no vencidas. Si el check no está marcado, facturas con días de vencido < 0 no se mostrarán."
<img width="1366" height="724" alt="Screenshot_3" src="https://github.com/user-attachments/assets/718f71b3-a441-455f-ba49-efc188b8bde9" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se recomienda siempre revisar la Cola de Notificaciones para confirmar que no existan rebotes o errores de envío."
<img width="1366" height="726" alt="Screenshot_4" src="https://github.com/user-attachments/assets/c4e829d0-e2d1-4d68-8d91-6751f769e587" />