### PR TITLE
Actualización de notas en Cálculo de Interés por Mora de Facturas

### DIFF
--- a/docs/balance-management/default-management-general/default-management.md
+++ b/docs/balance-management/default-management-general/default-management.md
@@ -63,7 +63,7 @@ En las líneas de cada entrada se visualiza:
 
 ![Entradas](/assets/img/docs/balance-management/bam-default19.png)
 
-::: note
+::: tip
 Si el check “No Muestra Deuda” está marcado, también se mostrarán facturas no vencidas.
 Si el check no está marcado, facturas con días de vencido < 0 no se mostrarán.
 :::
@@ -152,6 +152,6 @@ El proceso garantiza:
 
 * Envío automático de notificaciones con trazabilidad.
 
-::: note
+::: tip
 Se recomienda siempre revisar la Cola de Notificaciones para confirmar que no existan rebotes o errores de envío.
 :::

--- a/docs/balance-management/default-management-general/late-payment-interest-calculation.md
+++ b/docs/balance-management/default-management-general/late-payment-interest-calculation.md
@@ -20,7 +20,7 @@ En el cálculo de morosidad se obtiene y asigna al campo "Total de Tarifa" el im
 
 Para esto, si el nivel de morosidad tiene marcado el check "Cargo", primero se intenta obtener la tasa financiera definida en el SDN, si no existe entonces se toma la del nivel de morosidad, y como última opción se tomará desde el campo "Total de Tarifa" en el propio nivel de morosidad.
 
-::: note
+::: tip
 Cálculo de la Tasa Financiera:
 Tasa Final = (Días Vencido / Días del Mes) * Tasa de Interés
 :::
@@ -58,7 +58,7 @@ El proceso genera un lote de transacción financiera para cada factura procesada
 Si el término de pago de la factura tiene definido días de gracia, se considera esto para comparar con los días de vencido de la factura, y en caso que los días de vencido sean menores o  
 iguales a los días de gracia, entonces se genera el lote pero con importe en cero, y el informe de gasto no se genera.
 
-::: note
+::: tip
 Si el informe financiero tiene vinculado un lote de transacción financiera, entonces se asigna a la factura generada el tipo de documento correspondiente de "Nota de Débito" según la organización y grupo de impuestos del SDN (estos documentos Nota de débito no generan cálculo por mora).
 :::
 
@@ -129,6 +129,6 @@ En la asignación indica que se trata de una asignación de nota de crédito, es
 
 Cuando la factura tiene más de una asignación, se considera los días de vencido de la línea de asignación, y no los del cabezal de la factura. Tambíen se hace un prorrateo para saber qué porcentaje de la factura se ha asignado en cada una de las asignaciones.
 
-::: note
+::: tip
 Los lotes de transacción financiera se generan según la cantidad de asignaciones que tenga la factura.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Cálculo de la Tasa Financiera: Tasa Final = (Días Vencido / Días del Mes) * Tasa de Interés"
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/d234588f-7b22-40ff-bf31-6c1848ac8696" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si el informe financiero tiene vinculado un lote de transacción financiera, entonces se asigna a la factura generada el tipo de documento correspondiente de "Nota de Débito" según la organización y grupo de impuestos del SDN (estos documentos Nota de débito no generan cálculo por mora)."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/f801e5f2-78ff-49e5-9ab7-e0626f6d6c0e" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Los lotes de transacción financiera se generan según la cantidad de asignaciones que tenga la factura."
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/65fd18d2-cfae-4e03-9115-564a12559618" />
