### PR TITLE
Actualización de notas en Selección de Pago General

### DIFF
--- a/docs/balance-management/payment-selection-general/selection.md
+++ b/docs/balance-management/payment-selection-general/selection.md
@@ -35,7 +35,7 @@ En esta modalidad, todo se resuelve en un único documento:
 
 * Completar el documento y confirmar la emisión de los pagos.
 
-::: note
+::: tip
 Esta forma es útil cuando una sola persona gestiona tanto la selección de facturas como la definición de pagos.
 :::
 
@@ -71,7 +71,7 @@ Existen dos escenarios principales para crear una orden de pago:
 
 ![Campo](/assets/img/docs/balance-management/bam-balance-image237.png)
 
-::: note
+::: tip
 En ambos casos, el resultado es un documento de Orden de Pago, que lista los documentos seleccionados para cancelar.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Esta forma es útil cuando una sola persona gestiona tanto la selección de facturas como la definición de pagos."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/58454ba5-b6ab-4457-84cf-aaa0a1de08b0" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "En ambos casos, el resultado es un documento de Orden de Pago, que lista los documentos seleccionados para cancelar."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/dd54b952-1536-431f-ba90-fbf696f5430b" />