### PR TITLE
Actualización de notas en Recibo de Pago/Cobro

### DIFF
--- a/docs/balance-management/payments-and-receipts/Receipt.md
+++ b/docs/balance-management/payments-and-receipts/Receipt.md
@@ -126,7 +126,7 @@ Seleccionar con qué medio de pago se estará cobrando. Contado, Cheque al día,
 
 En caso de que exista una diferencia entre los Medios de Pago y los Documentos a Asignar, se podrá enviar dicha diferencia a un Cargo.
 
-::: note
+::: tip
 Si existe una diferencia pero no se selecciona un Cargo, los importes no cerrarán por lo que no se generará la Asignación automática.
 :::
 
@@ -204,7 +204,7 @@ Aquí **SI** deberemos marcar el check de Redondeo.
 
 * **Asignación Parcial:** Para poder hacer una asignación Parcial de las Facturas se deberá seleccionar las mismas desde el Smartbrowser de Asignar Facturas por el importe que se desea asignar.
 
-::: note 
+::: tip 
 Para poder asignar parcialmente un DxC en un recibo de cobro, al asignarlo, deben modificar en la columna "total del pago" el importe (inferior al total de la factura) que quieran aplicar. Esto dejará un importe abierto del Documento por Cobrar
 :::
 
@@ -212,7 +212,7 @@ Para poder asignar parcialmente un DxC en un recibo de cobro, al asignarlo, debe
 
 Como último paso en todos los casos se deberá Completar el documento mediante el botón Completar.
 
-::: note
+::: tip
 El sistema NO PERMITE asignar de más si no se marca el check de Redondeo.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si existe una diferencia pero no se selecciona un Cargo, los importes no cerrarán por lo que no se generará la Asignación automática."
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/1812d16c-f677-4c2b-82c1-6a64fce39a10" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Para poder asignar parcialmente un DxC en un recibo de cobro, al asignarlo, deben modificar en la columna "total del pago" el importe (inferior al total de la factura) que quieran aplicar. Esto dejará un importe abierto del Documento por Cobrar" y en el texto "El sistema NO PERMITE asignar de más si no se marca el check de Redondeo."
<img width="1366" height="768" alt="Screenshot_6" src="https://github.com/user-attachments/assets/0558ecaa-6092-404d-9ebf-b6e2fe592eb0" />
