### PR TITLE
Actualización de notas en Cierre de Caja

### DIFF
--- a/docs/financial-management/bank-statements/close-box.md
+++ b/docs/financial-management/bank-statements/close-box.md
@@ -61,7 +61,7 @@ Seleccione la opción **Completar**, ubicada en la parte inferior del documento.
 
 Seleccione la acción **Completar** y la opción **OK**, para completar el documento.
 
-::: note
+::: tip
 Recuerde que el procedimiento para gestionar el cierre de caja debe realizarce diariamente.
 :::
 
@@ -87,7 +87,7 @@ Luego nos aparecerá una ventana donde estará seleccionada el nombre de nuestra
 
 Posteriormente aparecen los movimientos que tenga registrados en su caja, en la fecha que determinó en su búsqueda. En este caso nos aparecen el pago generado a los empleados en la selección de pago y por otro lado tendremos el monto total de la transferencia que realizamos con el monto total de la nómina.
 
-::: note
+::: tip
 Cabe destacar que en el ejemplo que presentamos se evidencia la transferencia realizada y el pago de un solo empleado que fue con el que realizamos el proceso de nómina, sólo para este caso en específico, en su proceso le deben aparecer todos los empleados qué le procesaron la nómina
 :::
 
@@ -97,7 +97,7 @@ Seguidamente nos dirigimos a la ventana principal de nuestro cierre de caja y en
 
 Por último nos dirigimos a la ventana principal de nuestro cierre de caja y en el campo **Saldo Final** nos debe quedar un saldo de cero (0), eso quiere decir que los montos de la caja están correctos, el egreso de dinero que salió de nuestra caja para el pago de la nómina de los empleados y en monto ingresado a nuestra caja a través de la transferencia bancaria está correcto.
 
-::: warning
+::: tip
 Cabe destacar que el saldo final del cierre de la caja siempre debe quedar en cero 0. Sí no es así posiblemente esté realizando un procedimiento incorrecto
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Recuerde que el procedimiento para gestionar el cierre de caja debe realizarce diariamente."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/c68d618d-4661-4aba-b2fe-a59b999ce804" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Cabe destacar que en el ejemplo que presentamos se evidencia la transferencia realizada y el pago de un solo empleado que fue con el que realizamos el proceso de nómina, sólo para este caso en específico, en su proceso le deben aparecer todos los empleados qué le procesaron la nómina" y además se ha modificado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip", para que concuerde con el resto de alertas, se realizo el cambio en el siguiente texto "Cabe destacar que el saldo final del cierre de la caja siempre debe quedar en cero 0. Sí no es así posiblemente esté realizando un procedimiento incorrecto"
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/bffd4b7a-3532-4a50-8462-08e023ae2b82" />



