### PR TITLE
Actualización de notas en Caja Viáticos

### DIFF
--- a/docs/financial-management/cash-management-general/travel-box.md
+++ b/docs/financial-management/cash-management-general/travel-box.md
@@ -33,7 +33,7 @@ Se realiza la transferencia bancaria a caja viáticos por el monto correspondien
 
 Imagen 1. Transferencia Bancaria por Viáticos
 
-::: note
+::: tip
 Al realizar el proceso de transferencia bancaria, es generado un egreso de banco y un ingreso a caja viáticos. De igual manera, es creado un cobro en caja y un pago en pago/cobro.
 :::
 
@@ -65,7 +65,7 @@ Se realiza el procedimiento regular para generar un cierre de caja, seleccionand
 
 Imagen 5. Cierre de Caja Viáticos
 
-::: note
+::: tip
 Se selecciona el registro de la relación de factura realizada anteriormente con el monto total de la factura. Adicional a ello, se selecciona el registro de la transferencia bancaria realizada anteriormente. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0).
 :::
 
@@ -81,7 +81,7 @@ Se realiza la transferencia bancaria a caja viáticos por el monto correspondien
 
 Imagen 6. Transferencia Bancaria por Viáticos
 
-::: note
+::: tip
 Al realizar el proceso de transferencia bancaria, es generado un egreso de banco y un ingreso a caja viáticos. De igual manera, es creado un cobro en caja y un pago en pago/cobro.
 :::
 
@@ -109,7 +109,7 @@ Imagen 9. Relación de Facturas de Gastos
 
 Realice el procedimiento regular para generar un cierre de caja, explicado en el documento Registro de Cierre de Caja, elaborado por Solop ERP, seleccionando la cuenta **Caja Viáticos** y el tipo de documento **Cierre de Caja Viáticos**.
 
-::: note
+::: tip
 Se selecciona el registro de la relación de factura realizada anteriormente con el monto total de la factura. Adicional a ello, se selecciona el registro de la transferencia bancaria realizada anteriormente. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0).
 :::
 
@@ -117,7 +117,7 @@ Se selecciona el registro de la relación de factura realizada anteriormente con
 
 Imagen 10. Cierre de Caja Viáticos
 
-::: warning
+::: tip
 Si el monto total de la transferencia bancaria realizada anteriormente a la caja viáticos del empleado es mayor al monto total gastado por el mismo, es necesario que el cierre de caja se genere en estado **Borrador** y se proceda a realizar una transferencia bancaria por el excedente del monto, antes de realizar el cierre de la caja viáticos del empleado nuevamente.
 :::
 
@@ -129,7 +129,7 @@ Realice el procedimiento regular para generar una transferencia bancaria, explic
 
 Imagen 11. Transferencia Bancaria por Excedente de Viáticos
 
-::: note
+::: tip
 Al realizar el proceso de transferencia bancaria, es generado un egreso de caja viáticos y un ingreso a banco. De igual manera, es creado un pago en caja y un cobro en pago/cobro.
 :::
 
@@ -153,7 +153,7 @@ Ubique el registro del cierre de caja **CCV-2**, generado anteriormente en estad
 
 Imagen 14. Cierre de Caja Viáticos
 
-::: note
+::: tip
 Se selecciona el registro de la transferencia bancaria realizada desde la cuenta caja viáticos, por el monto restante abierto en dicha caja. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0).
 :::
 
@@ -169,7 +169,7 @@ Se realiza la transferencia bancaria a caja viáticos por el monto correspondien
 
 Imagen 15. Transferencia Bancaria por Viáticos
 
-::: note
+::: tip
 Al realizar el proceso de transferencia bancaria, es generado un egreso de banco y un ingreso a caja viáticos. De igual manera, es creado un cobro en caja y un pago en pago/cobro.
 :::
 
@@ -197,7 +197,7 @@ Imagen 18. Relación de Facturas de Gastos
 
 Realice el procedimiento regular para generar un cierre de caja, explicado en el documento Registro de Cierre de Caja, elaborado por Solop ERP, seleccionando la cuenta **Caja Viáticos** y el tipo de documento **Cierre de Caja Viáticos**.
 
-::: note
+::: tip
 Se selecciona el registro de la relación de factura realizada anteriormente con el monto total de la factura. Adicional a ello, se selecciona el registro de la transferencia bancaria realizada anteriormente. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0).
 :::
 
@@ -205,7 +205,7 @@ Se selecciona el registro de la relación de factura realizada anteriormente con
 
 Imagen 19. Cierre de Caja Viáticos
 
-::: warning
+::: tip
 Si el monto total de la transferencia bancaria realizada anteriormente a la caja viáticos del empleado es menor al monto total gastado por el mismo, es necesario que el cierre de caja se genere en estado **Borrador** y se proceda a realizar una caja con el cargo **Monto no Reembolsable**, reflejando el monto total gastado de más, antes de realizar el cierre de la caja viáticos del empleado nuevamente.
 :::
 
@@ -225,6 +225,6 @@ Ubique el registro del cierre de caja **CCV-3**, generado anteriormente en estad
 
 Imagen 21. Cierre de Caja Viáticos
 
-::: note
+::: tip
 Se selecciona el registro de la transferencia bancaria realizada desde la cuenta caja viáticos, por el monto restante abierto en dicha caja. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0).
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al realizar el proceso de transferencia bancaria, es generado un egreso de banco y un ingreso a caja viáticos. De igual manera, es creado un cobro en caja y un pago en pago/cobro."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/0053b1db-5bb9-4343-a5fb-39181a3f48d8" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se selecciona el registro de la relación de factura realizada anteriormente con el monto total de la factura. Adicional a ello, se selecciona el registro de la transferencia bancaria realizada anteriormente. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0)."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/5ca6c185-973c-4f8f-ba50-bb71394b49f4" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al realizar el proceso de transferencia bancaria, es generado un egreso de banco y un ingreso a caja viáticos. De igual manera, es creado un cobro en caja y un pago en pago/cobro."
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/287d56b9-81e5-4e2a-94d1-9b21dcf0055a" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se selecciona el registro de la relación de factura realizada anteriormente con el monto total de la factura. Adicional a ello, se selecciona el registro de la transferencia bancaria realizada anteriormente. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0)."
<img width="1366" height="768" alt="Screenshot_6" src="https://github.com/user-attachments/assets/a800b761-2885-4566-b786-326619811009" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" en el siguiente texto "Si el monto total de la transferencia bancaria realizada anteriormente a la caja viáticos del empleado es mayor al monto total gastado por el mismo, es necesario que el cierre de caja se genere en estado Borrador y se proceda a realizar una transferencia bancaria por el excedente del monto, antes de realizar el cierre de la caja viáticos del empleado nuevamente."
<img width="1366" height="768" alt="Screenshot_7" src="https://github.com/user-attachments/assets/e88c0f59-2184-4b3f-b267-945b5b2f2ace" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al realizar el proceso de transferencia bancaria, es generado un egreso de caja viáticos y un ingreso a banco. De igual manera, es creado un pago en caja y un cobro en pago/cobro."
<img width="1366" height="768" alt="Screenshot_8" src="https://github.com/user-attachments/assets/89172117-1a33-4911-a31e-31ce57556258" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se selecciona el registro de la transferencia bancaria realizada desde la cuenta caja viáticos, por el monto restante abierto en dicha caja. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0)."
<img width="1366" height="768" alt="Screenshot_9" src="https://github.com/user-attachments/assets/34723710-b175-4858-b49d-c0e43800c423" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al realizar el proceso de transferencia bancaria, es generado un egreso de banco y un ingreso a caja viáticos. De igual manera, es creado un cobro en caja y un pago en pago/cobro."
<img width="1366" height="768" alt="Screenshot_10" src="https://github.com/user-attachments/assets/a47bc913-d9e5-4061-b386-201895440bd6" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se selecciona el registro de la relación de factura realizada anteriormente con el monto total de la factura. Adicional a ello, se selecciona el registro de la transferencia bancaria realizada anteriormente. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0)."
<img width="1366" height="768" alt="Screenshot_11" src="https://github.com/user-attachments/assets/3752e33d-1c43-4699-8b73-2b5b74f94d5d" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" en el siguiente texto "Si el monto total de la transferencia bancaria realizada anteriormente a la caja viáticos del empleado es menor al monto total gastado por el mismo, es necesario que el cierre de caja se genere en estado Borrador y se proceda a realizar una caja con el cargo Monto no Reembolsable, reflejando el monto total gastado de más, antes de realizar el cierre de la caja viáticos del empleado nuevamente."
<img width="1366" height="506" alt="Screenshot_12" src="https://github.com/user-attachments/assets/3e73799d-7745-4225-9489-a9eb104d5d9d" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se selecciona el registro de la transferencia bancaria realizada desde la cuenta caja viáticos, por el monto restante abierto en dicha caja. Lo anterior, con la finalidad de llevar la cuenta caja viáticos a su monto inicial, para este ejemplo el monto inicial es cero (0)."
<img width="1366" height="768" alt="Screenshot_13" src="https://github.com/user-attachments/assets/21e5c742-1d1f-45d0-bbd4-ababe1fa9506" />
