### PR TITLE
Actualización de notas en Cheques Diferidos

### DIFF
--- a/docs/financial-management/payments-methods/deferred-checks.md
+++ b/docs/financial-management/payments-methods/deferred-checks.md
@@ -181,7 +181,7 @@ Cheque a Pagar
 * Se debe anular el pago del cheque original.
 * Se concilia el “Rechazo del Cheque” que está positivo con la “Reversión” del Pago.
 
-::: note
+::: tip
 El asiento se neutraliza.
 :::
 
@@ -193,7 +193,7 @@ Cheque a Cobrar
 * Se debe anular el cobro del cheque original.
 * Se concilia el “Rechazo del Cheque” que está positivo con la “Reversión” del cobro.
 
-::: note
+::: tip
 El asiento se neutraliza.
 :::
 
@@ -205,7 +205,7 @@ Cheque a Diferido a Pagar
 * Se debe anular el pago del cheque original.
 * Se concilia el “Rechazo del Cheque” que está positivo con la “Reversión” del Pago.
 
-::: note
+::: tip
 El asiento se neutraliza.
 :::
 
@@ -217,11 +217,11 @@ Cheque Diferido a Cobrar
 * Se debe anular el cobro del cheque original.
 * Se concilia el “Rechazo del Cheque” que está positivo con la “Reversión” del cobro.
 
-::: note
+::: tip
 El asiento se neutraliza.
 :::
 
-::: warning
+::: tip
 Importante: cuando un Pago/Cobro se encuentra vinculado a una línea de estado de cuenta bancario, al anularlo se marcará (tanto en el documento original como en el reverso) el check **Asignado** mientras que el check **Conciliado** se mantendrá sin marcar. Esto permite conciliar el rechazo del cheque con la reversión del cobro.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en todas las alertas de "El asiento se neutraliza."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/37e785fe-4199-42dd-8483-0c13a4cfc481" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" en el siguiente texto "Importante: cuando un Pago/Cobro se encuentra vinculado a una línea de estado de cuenta bancario, al anularlo se marcará (tanto en el documento original como en el reverso) el check Asignado mientras que el check Conciliado se mantendrá sin marcar. Esto permite conciliar el rechazo del cheque con la reversión del cobro."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/7e5b19e3-fb15-498e-8589-bbc00c86847d" />

