### PR TITLE
Actualización de notas en Transferencia Bancaria

### DIFF
--- a/docs/financial-management/payments-methods/transfer.md
+++ b/docs/financial-management/payments-methods/transfer.md
@@ -69,7 +69,7 @@ Seleccione la opción **OK**, para generar en Solop ERP la transferencia entre c
 
 Podrá apreciar el resultado del proceso luego de su ejecución.
 
-::: note
+::: tip
 Al realizar el proceso de transferencia bancaria, es generado un egreso en la cuenta seleccionada en el campo **Cuenta bancaria desde** y un ingreso en la cuenta seleccionada en el campo **Cuenta Bancaria a Transferir**.
 :::
 
@@ -97,7 +97,7 @@ Si en la transferencia bancaria en el campo **Cuenta Bancaria a Transferir** fue
 
 Imagen 19. Cobro en Ventana Pago/Cobro
 
-::: note
+::: tip
 Si en el campo **Documento Destino** de la transferencia bancaria no se colocó el número de la transacción, el número de documento a mostrar del cobro en la ventana **Pago/Cobro** será el mismo que se número colocado en el campo **No. del Documento** de la transferencia bancaria.
 :::
 
@@ -107,7 +107,7 @@ Si en la transferencia bancaria en el campo **Cuenta Bancaria a Transferir** fue
 
 Imagen 20. Cobro en Ventana Caja
 
-::: note
+::: tip
 Si en el campo **Documento Destino** de la transferencia bancaria no se colocó el número de la transacción, el número de documento a mostrar del cobro en la ventana **Caja** será el mismo que se número colocado en el campo **No. del Documento** de la transferencia bancaria.
 :::
 
@@ -121,7 +121,7 @@ Si usted utiliza un txt para transferirle a todo el personal puede realizar una 
 
 Si usted paga particularmente a cada uno de sus empleados debe realizar una transferencia por cada pago que fué realizado para cada uno de sus empleados.
 
-::: warning
+::: tip
 Recuerde que al realizar la transferencia usted esta es registrando cada uno de los pagos que salen del banco. Por tal motivo debe tener especial cuidado en cuanto a monto y a número de referencia
 :::
 
@@ -151,7 +151,7 @@ Seleccione en el campo **Fecha Contable** la misma fecha con la que registró su
 
 Imagen 1. Transferencia Bancaria
 
-::: warning
+::: tip
 Por favor NO tildar el check que dice conciliación automática
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al realizar el proceso de transferencia bancaria, es generado un egreso en la cuenta seleccionada en el campo Cuenta bancaria desde y un ingreso en la cuenta seleccionada en el campo Cuenta Bancaria a Transferir."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/741645cf-661d-4bc4-8ebc-9e49224202b5" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si en el campo Documento Destino de la transferencia bancaria no se colocó el número de la transacción, el número de documento a mostrar del cobro en la ventana Pago/Cobro será el mismo que se número colocado en el campo No. del Documento de la transferencia bancaria."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/652a5e85-224d-4508-91b2-414aa5c256e9" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si en el campo Documento Destino de la transferencia bancaria no se colocó el número de la transacción, el número de documento a mostrar del cobro en la ventana Caja será el mismo que se número colocado en el campo No. del Documento de la transferencia bancaria."
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/4bdb0c7d-72f8-4f4a-9697-44eab94e9b42" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" en el siguiente texto "Recuerde que al realizar la transferencia usted esta es registrando cada uno de los pagos que salen del banco. Por tal motivo debe tener especial cuidado en cuanto a monto y a número de referencia"
<img width="1366" height="768" alt="Screenshot_6" src="https://github.com/user-attachments/assets/9d83f1ba-cc54-4655-869d-52aed8edcb4b" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "warning" a "tip" en el siguiente texto "Por favor NO tildar el check que dice conciliación automática"
<img width="1366" height="768" alt="Screenshot_7" src="https://github.com/user-attachments/assets/c39c81ae-f96d-4ef9-8952-771ca4a477cd" />
