### PR TITLE
Actualización de notas en Activos Fijos

### DIFF
--- a/docs/asset-management/fixed-assets.md
+++ b/docs/asset-management/fixed-assets.md
@@ -93,7 +93,7 @@ Seleccione en el campo **Organización**, la organización para la cual esta rea
 
 Imagen 11. Campo Organización de la Pestaña
 
-::: note
+::: tip
 Solop ERP permite que una compañía que posee más de una organización, registre la configuración contable del grupo de activo fijo por organización. El registro podría ser:
 :::
 
@@ -133,7 +133,7 @@ Introduzca en el campo **Vida Útil - Años**, la cantidad de años de vida úti
 
 Imagen 16. Campo Vida Útil - Años
 
-::: note
+::: tip
 Al ingresar un valor en el campo **Vida Útil - Años**, Solop ERP refleja en los campos **Vida Útil - Años (Fiscal)**, **Vida Útil - Meses** y **Vida Útil - Meses (Fiscal)**, el equivalente al campo correspondiente.
 :::
 
@@ -171,7 +171,7 @@ Imagen 21. Campo Perdidas por Disposición
 
 Ubique o cree de manera regular la categoría de producto a la que desea asociar el grupo de activo fijo, de esta manera podrá con los productos bajo esta categoría realizar operaciones de activo fijo, y seleccione en el campo **Grupo de Activo Fijos**, el grupo de activo previamente configurado.
 
-::: note
+::: tip
 Al ingresar un valor en el campo **Grupo de Activo Fijos**, Solop ERP generará un activo fijo al crear una recepción de un producto asociado a esta categoría.
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Solop ERP permite que una compañía que posee más de una organización, registre la configuración contable del grupo de activo fijo por organización. El registro podría ser:"
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/176cf2ee-9e74-490f-b218-ea67c8df8d34" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al ingresar un valor en el campo Vida Útil - Años, Solop ERP refleja en los campos Vida Útil - Años (Fiscal), Vida Útil - Meses y Vida Útil - Meses (Fiscal), el equivalente al campo correspondiente."
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/fd38f818-e249-4d08-9ea3-df8eeebf75cb" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Al ingresar un valor en el campo Grupo de Activo Fijos, Solop ERP generará un activo fijo al crear una recepción de un producto asociado a esta categoría."
<img width="1366" height="768" alt="Screenshot_5" src="https://github.com/user-attachments/assets/aa600aa1-0ed1-4344-af79-5c5c7224d981" />

