### PR TITLE
Actualización de notas en Procesos de Facturación

### DIFF
--- a/docs/frequently-asked-questions/billing.md
+++ b/docs/frequently-asked-questions/billing.md
@@ -46,7 +46,7 @@ El criterio que se maneja es que sólo será Contado una factura si junto al com
 
 En caso de que el Cobro no se genere automáticamente con la facturación, se entiende que serán siempre a crédito aunque su crédito sea con un plazo de vencimiento "inmediato".
 
-::: note
+::: tip
 Para poder generar una factura con Regla de Pago "Efectivo" será necesario crear una caja chica (en ventana Definición de Cajas) en la organización en cuestión.
 :::
 
@@ -106,7 +106,7 @@ Hay varios procesos de generar Notas de Crédito (Nota de Débito es otra cosa, 
 2. Copiar Líneas. (Factura)
 3. Proceso de Crear NC desde Devolución.
 
-::: note
+::: tip
 Educación y Agencia utilizan el primero generalmente.
 :::
 
@@ -154,7 +154,7 @@ Las Notas de Débito Proveedor son Facturas que el Proveedor le emite al CLIENTE
 
 Para luego cobrarle al cliente se genera una Nota de Débito al Cliente por este mismo importe.
 
-::: note
+::: tip
 Estas Notas de Débito NO TIENEN IVA, son todas exentas, ya que el que descuenta el iva compras  es el Cliente.
 :::
 
@@ -235,7 +235,7 @@ Al momento de ejecutarse este proceso, se verifica que cada una de las facturas 
 
 Al completarse la Nota de Crédito de Documento por Cobrar, se verifican las líneas de orden de los Documentos por Cobrar asignados en pestaña "CFE Referidos", y en caso de que ninguna línea tenga cantidad ordenada distinta a la facturada, se quita el check de "En Negociacion" del Documento por Cobrar.
 
-::: note
+::: tip
 EL SISTEMA NO REALIZA ASIGNACIONES POR LÍNEA SINO POR FACTURA, por lo que si los pagos no cancelan totalmente los Documentos por Cobrar no se deben asignar parcialmente.
 :::
 
@@ -293,7 +293,7 @@ Realiza la identificación del descuento porque el CFE Recibido posee dos campos
 Uno es el campo Precio de Lista (I_Invoice.PriceList) donde se agrega el precio del producto sin descuento y el segundo es el Precio Actual (I_Invoice.PriceActual) donde muestra el precio con descuento.
 
 
-::: note
+::: tip
 En el xml de respuesta, el MontoTiemTotal viene multiplicado por la cantidad, el sistema procede a dividir la cantidad para tener el monto de item por el valor real. De esta forma el Precio Actual refleja correctamente el monto con descuento.
 :::
 
@@ -313,7 +313,7 @@ Esto se debe a que no puede determinar que término de pago se desea definir en 
 
 **Solución:** Para solucionarlo lo ideal sería abrir en la ventana de “Órdenes de Venta” todas las Ordenes de venta que se están intentando facturar Varios Términos de Pago en las Órdenes de Venta seleccionadas.
 
-::: note
+::: tip
 Ver las mismas en formato “Grilla” para identificar qué Orden de Venta tiene un Término de Pago diferente.
 Para modificarlo deberá Rectivar la Orden, modificar el Término de Pago y luego completarla nuevamente.
 :::


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Para poder generar una factura con Regla de Pago "Efectivo" será necesario crear una caja chica (en ventana Definición de Cajas) en la organización en cuestión."
<img width="1366" height="768" alt="Screenshot_6" src="https://github.com/user-attachments/assets/d18ce57a-ddeb-493d-b24b-f42b88997251" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Educación y Agencia utilizan el primero generalmente."
<img width="1366" height="768" alt="Screenshot_7" src="https://github.com/user-attachments/assets/a0cef9c9-7055-4d1f-bc95-943a432df373" />


Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Estas Notas de Débito NO TIENEN IVA, son todas exentas, ya que el que descuenta el iva compras  es el Cliente."
<img width="1366" height="768" alt="Screenshot_8" src="https://github.com/user-attachments/assets/bfadabf3-00d0-4849-b232-a69e781784cd" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "EL SISTEMA NO REALIZA ASIGNACIONES POR LÍNEA SINO POR FACTURA, por lo que si los pagos no cancelan totalmente los Documentos por Cobrar no se deben asignar parcialmente."
<img width="1366" height="768" alt="Screenshot_9" src="https://github.com/user-attachments/assets/11be6604-01fe-4cf6-a112-6c085a67fde4" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "En el xml de respuesta, el MontoTiemTotal viene multiplicado por la cantidad, el sistema procede a dividir la cantidad para tener el monto de item por el valor real. De esta forma el Precio Actual refleja correctamente el monto con descuento."
<img width="1366" height="768" alt="Screenshot_10" src="https://github.com/user-attachments/assets/ef2c014c-0193-4021-b33b-5ade62bab146" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Ver las mismas en formato “Grilla” para identificar qué Orden de Venta tiene un Término de Pago diferente. Para modificarlo deberá Rectivar la Orden, modificar el Término de Pago y luego completarla nuevamente."
<img width="1366" height="768" alt="Screenshot_11" src="https://github.com/user-attachments/assets/a83db531-db04-41c6-8786-ff31f9aea801" />
