### PR TITLE
Actualización de notas en Gestión de Agencia de Publicidad

### DIFF
--- a/docs/frequently-asked-questions/verticals-faqs/agency-management.md
+++ b/docs/frequently-asked-questions/verticals-faqs/agency-management.md
@@ -86,7 +86,7 @@ Proyecto de RRP                                 Agencia RRPP
 
 Proyecto de Medios Digitales             Agencia de Medios Digitales
 
-::: note
+::: tip
 Si no se obtuvo sello de origen se lanza una excepción.
 :::
 
@@ -211,7 +211,7 @@ Por lo tanto al generarse la Orden de venta Honorarios esta no discrimina por ca
 
 En el caso de recibo de canje, si no se ingresa el número del recibo de canje, entonces se obtiene desde la secuencia correspondiente del tipo de documento Recibo de Cobro (secuencia automática incremental)
 
-::: note
+::: tip
  Este cambio aplica solamente a la ventana de "Recibo de Pago", en la ventana de "Recibo de Cobro" el número de recibo de canje seguirá siendo obligatorio su ingreso manual
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Si no se obtuvo sello de origen se lanza una excepción."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/3d820d91-7f46-4269-9b98-6d78d2c08a50" />

Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Este cambio aplica solamente a la ventana de "Recibo de Pago", en la ventana de "Recibo de Cobro" el número de recibo de canje seguirá siendo obligatorio su ingreso manual"
<img width="1366" height="768" alt="Screenshot_4" src="https://github.com/user-attachments/assets/8976abab-c917-487e-9f16-ffc017a1ae6c" />
