### PR TITLE
Actualización de notas en Contrato de Servicio de Agencia

### DIFF
--- a/docs/verticals/agency-management/service-agency-contract.md
+++ b/docs/verticals/agency-management/service-agency-contract.md
@@ -52,7 +52,7 @@ Podremos acceder a la misma desde la ventana Cálculo de Comisiones mediante el 
 
 Esta se genera en una Orden de Venta distinta de la Orden de Venta de la Inversión del Cliente.
 
-::: note
+::: tip
 Se marca como permite facturar = SI la Orden de Venta Honorarios cuando se configura permite facturar = Si en la orden de venta inversión (que le dio origen).
 :::
 


### PR DESCRIPTION
Se ha actualizado el componente de alertas/notas para cambiar la etiqueta de visualización de "Note" a "tip" en el siguiente texto "Se marca como permite facturar = SI la Orden de Venta Honorarios cuando se configura permite facturar = Si en la orden de venta inversión (que le dio origen)."
<img width="1366" height="768" alt="Screenshot_3" src="https://github.com/user-attachments/assets/c7bfa57d-173b-432e-b3d1-0ef70999c882" />
